### PR TITLE
v1.61

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,15 +5,8 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="f5b952a7-ff71-4d73-ba1e-cde5be983fca" name="Changes" comment="v1.56: Switched from using zipfile module to zipfile36 to solve long file path issues">
-      <change afterPath="$PROJECT_DIR$/enable_long_pathnames.py" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/output/TPG ITG Export Scrubber v1.56.exe" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/ITG_export_scrub_gui.py" beforeDir="false" afterPath="$PROJECT_DIR$/ITG_export_scrub_gui.py" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/output/TPG ITG Export Scrubber 1.12.exe" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/output/TPG ITG Export Scrubber v1.5.exe" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/output/TPG ITG Export Scrubber v1.51.exe" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/output/TPG ITG Export Scrubber v1.54.exe" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/output/TPG ITG Export Scrubber v1.55.exe" beforeDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -222,7 +215,7 @@
       <workItem from="1734281685691" duration="18000" />
       <workItem from="1734444461769" duration="14000" />
       <workItem from="1734444673763" duration="15512000" />
-      <workItem from="1734532506701" duration="4150000" />
+      <workItem from="1734532506701" duration="10508000" />
     </task>
     <task id="LOCAL-00001" summary="*">
       <option name="closed" value="true" />
@@ -448,7 +441,15 @@
       <option name="project" value="LOCAL" />
       <updated>1734544556748</updated>
     </task>
-    <option name="localTasksCounter" value="29" />
+    <task id="LOCAL-00029" summary="v1.56: Switched from using zipfile module to zipfile36 to solve long file path issues">
+      <option name="closed" value="true" />
+      <created>1734544780229</created>
+      <option name="number" value="00029" />
+      <option name="presentableId" value="LOCAL-00029" />
+      <option name="project" value="LOCAL" />
+      <updated>1734544780229</updated>
+    </task>
+    <option name="localTasksCounter" value="30" />
     <servers />
   </component>
   <component name="TypeScriptGeneratedFilesManager">
@@ -511,7 +512,7 @@
     <SUITE FILE_PATH="coverage/ITG_export_scrubber$ITG_export_scrubber.coverage" NAME="ITG_export_scrubber Coverage Results" MODIFIED="1733788502062" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="coverage.py" COVERAGE_BY_TEST_ENABLED="false" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$" />
     <SUITE FILE_PATH="coverage/ITG_export_scrubber$ITG_export_scrub_gui.coverage" NAME="ITG_export_scrub_gui Coverage Results" MODIFIED="1734218216520" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="coverage.py" COVERAGE_BY_TEST_ENABLED="false" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$" />
     <SUITE FILE_PATH="coverage/ITG_export_scrubber$pandas_table_test.coverage" NAME="pandas table test Coverage Results" MODIFIED="1734198969534" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="coverage.py" COVERAGE_BY_TEST_ENABLED="false" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$/Test files" />
-    <SUITE FILE_PATH="coverage/ITG_export_scrub_gui_py$ITG_export_scrub_gui.coverage" NAME="ITG_export_scrub_gui Coverage Results" MODIFIED="1734543036060" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="coverage.py" COVERAGE_BY_TEST_ENABLED="false" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$" />
+    <SUITE FILE_PATH="coverage/ITG_export_scrub_gui_py$ITG_export_scrub_gui.coverage" NAME="ITG_export_scrub_gui Coverage Results" MODIFIED="1734564238551" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="coverage.py" COVERAGE_BY_TEST_ENABLED="false" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$" />
     <SUITE FILE_PATH="coverage/ITG_export_scrubber$ITG_scrub_with_pandas_test.coverage" NAME="ITG scrub with pandas test Coverage Results" MODIFIED="1734196325151" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="coverage.py" COVERAGE_BY_TEST_ENABLED="false" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$/Test files" />
     <SUITE FILE_PATH="coverage/ITG_export_scrubber$html_table_test.coverage" NAME="html table test Coverage Results" MODIFIED="1734096311733" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="coverage.py" COVERAGE_BY_TEST_ENABLED="false" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$" />
   </component>

--- a/ITG_export_scrub_gui.py
+++ b/ITG_export_scrub_gui.py
@@ -242,7 +242,9 @@ class MainPage(AppPage):
         # Unzip input
         try:
             with ZipFile(input_zip, 'r') as in_zip:
-                in_zip.extractall(export_dir)
+                for file in in_zip.infolist():
+                    if file.filename in keep_csv:
+                        in_zip.extract(file, export_dir)
         except FileNotFoundError:
             self.log_error(error_log, f'{input_zip} not found.'
                                       f'More Info: {traceback.format_exc()}'
@@ -348,6 +350,24 @@ class MainPage(AppPage):
                               'installed_by',
                               'Equipment make & Model',
                               'resource_type', 'resource_id',
+                              'configuration_status', 'asset_tag',
+                              'DHCP Server', 'DHCP Scope',
+                              'DHCP Reservations', 'DNS Server(s)',
+                              'Default Gateway Device', 'Firewall',
+                              'Access Point(s)',
+                              'Wireless Controller (Application)',
+                              'Wireless Controller (Hardware)',
+                              'Management Credentials', 'VLAN #',
+                              'Backup Radar Report Recipients (Email)'
+                              ' or Link Contacts',
+                              'Backup Radar Reporting Notes',
+                              'Backup Server/NAS Management Login',
+                              'Local Backup Encryption Key',
+                              'Backup Copy Job Name',
+                              'Backup Copy Target',
+                              'Backup Copy Encryption',
+                              'Configuration Backup to Cloud Connect?',
+                              'SMB Login',
                               ]
 
             # Continue with unpacking current csv to list of lists
@@ -521,6 +541,7 @@ class MainPage(AppPage):
                                      self._vars['Post Job'].get(),
                                      self._vars['Zip?'].get(),
                                      )
+                self.input_file = ''
             else:
                 for file in os.listdir(self.input_folder):
                     self.status.set(f'Processing {file} ...')
@@ -533,6 +554,7 @@ class MainPage(AppPage):
                         )
                         if self.err_present == 1:
                             self.err_count += 1
+                self.input_folder = ''
 
             if self.err_count == 0 and self.err_present == 0:
                 self.status.set('Processing Complete. '
@@ -542,6 +564,7 @@ class MainPage(AppPage):
                                 'but errors are present.'
                                 '\nPlease refer to the error file which will '
                                 'be contained in the target directory.')
+                self.err_count = 0
 
     def _on_target(self):
         """Command to choose a target folder/file"""
@@ -595,7 +618,7 @@ class Application(tk.Tk):
         super().__init__(*args, **kwargs)
         self.m_page = ''
         self.main_label = ''
-        self.title(" TPG ITG Export Scrubber v1.56")
+        self.title(" TPG ITG Export Scrubber v1.61")
         self.minsize(400, 350)
         self.main_page()
 


### PR DESCRIPTION
- Now only unzip what we need as opposed to unzipping the entire export and ignoring what we don't need. This saves greatly on time processing time and file storage used in the process.
- Changed behavior so that new targets must be selected after a processing run while the app is left open.
- Changed behavior so that "errors present" status only shows after the processing job that created the error. Subsequent successful runs will not report error present
- Added more items to the columns to delete list based on client feedback.